### PR TITLE
Bug fixes

### DIFF
--- a/build-termbox.sh
+++ b/build-termbox.sh
@@ -10,7 +10,7 @@ if [ ! -f libtermbox.a ] || [ "$1" == "-f" ]; then
     cd termbox-master
     ./waf configure
     ./waf install --targets=termbox_static --destdir=.
-    mv build/src/libtermbox.a ..
+    mv usr/local/lib/libtermbox.a ../libtermbox.a
     cd ..
     rm -rf termbox-master
 fi

--- a/build-termbox.sh
+++ b/build-termbox.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $DIR
+DIR=$(dirname "$0")
+cd "$DIR"
 if [ ! -f libtermbox.a ] || [ "$1" == "-f" ]; then
     echo "Building Termbox"
     rm -rf termbox-master

--- a/source/termbox/color.d
+++ b/source/termbox/color.d
@@ -1,4 +1,4 @@
-module color;
+module termbox.color;
 
 /* Colors (see struct Cell's fg and bg fields). */
 enum Color : ushort {

--- a/source/termbox/keyboard.d
+++ b/source/termbox/keyboard.d
@@ -1,4 +1,4 @@
-module keyboard;
+module termbox.keyboard;
 
 // Key constants. See also struct Event's key field.
 enum Key : ushort {

--- a/source/termbox/package.d
+++ b/source/termbox/package.d
@@ -1,7 +1,7 @@
 module termbox;
 
-public import color;
-public import keyboard;
+public import termbox.color;
+public import termbox.keyboard;
 
 /* A cell, single conceptual entity on the terminal screen. The terminal screen
  * is basically a 2d array of cells. It has the following fields:


### PR DESCRIPTION
Fixed two bugs:
1. It would put the `libtermbox.a` file in dependent package's dir, and then fail to compile, because thats not where it should be.
2. If dependent package has module named `color` or `keyboard`, it'd fail to compile.