### PR TITLE
Fixes Issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Termbox-d is meant to be used as a dub package. Just install it by putting it in
 `dub.sdl` or `dub.json` file.
 
 ```sdl
-dependency "termbox" version="*"
+dependency "termbox" version="~master"
 ```
 
 or
 
 ```json
 "dependencies": {
-    "termbox": { "version": "*" }
+    "termbox": { "version": "~master" }
 }
 ```
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -5,5 +5,5 @@ license "MIT"
 homepage "https://github.com/zyedidia/termbox-d"
 
 targetType "sourceLibrary"
-sourceFiles "libtermbox.a"
+lflags "$PACKAGE_DIR/libtermbox.a"
 preGenerateCommands "bash $PACKAGE_DIR/build-termbox.sh"


### PR DESCRIPTION
Fixes Issue #4 .  
For some reason, if a dependency of a dependency has a static library listed as a sourceFile, it won't be linked.
  
But if the static library is listed as a lflag, it gets passed to linker at end always, so libtermbox.a is always linked.